### PR TITLE
Fix compilation of jte templates

### DIFF
--- a/src/test/kotlin/io/javalin/TestTemplates.kt
+++ b/src/test/kotlin/io/javalin/TestTemplates.kt
@@ -11,6 +11,7 @@ import com.mitchellbosecke.pebble.PebbleEngine
 import com.mitchellbosecke.pebble.loader.ClasspathLoader
 import gg.jte.ContentType
 import gg.jte.TemplateEngine
+import io.javalin.jte.JteTestPage
 import io.javalin.jte.PrecompileJteTestClasses
 import io.javalin.plugin.rendering.JavalinRenderer
 import io.javalin.plugin.rendering.markdown.JavalinCommonmark
@@ -172,6 +173,4 @@ class TestTemplates {
         app.get("/") { it.render("/templates/freemarker/test-with-base.ftl", model("foo", "baz")) }
         assertThat(http.get("/").body?.string()).contains("<h3>baz</h3>")
     }
-
-    data class JteTestPage(val hello: String, val world: String)
 }

--- a/src/test/kotlin/io/javalin/jte/JteTestPage.java
+++ b/src/test/kotlin/io/javalin/jte/JteTestPage.java
@@ -1,0 +1,19 @@
+package io.javalin.jte;
+
+public class JteTestPage {
+    private final String hello;
+    private final String world;
+
+    public JteTestPage(String hello, String world) {
+        this.hello = hello;
+        this.world = world;
+    }
+
+    public String getHello() {
+        return hello;
+    }
+
+    public String getWorld() {
+        return world;
+    }
+}

--- a/src/test/kotlin/io/javalin/jte/PrecompileJteTestClasses.java
+++ b/src/test/kotlin/io/javalin/jte/PrecompileJteTestClasses.java
@@ -11,8 +11,8 @@ public class PrecompileJteTestClasses {
     public static final String PACKAGE_NAME = "io.javalin.jte.precompiled";
 
     public static void main(String[] args) {
-        Path inputDirectory = Paths.get("javalin/src/test/resources/templates/jte");
-        Path outputDirectory = Paths.get("javalin/src/test/java");
+        Path inputDirectory = Paths.get("src/test/resources/templates/jte");
+        Path outputDirectory = Paths.get("src/test/java");
 
         TemplateEngine templateEngine = TemplateEngine.create(new DirectoryCodeResolver(inputDirectory), outputDirectory, ContentType.Html, null, PACKAGE_NAME);
         templateEngine.generateAll();

--- a/src/test/kotlin/io/javalin/jte/precompiled/JtetestGenerated.java
+++ b/src/test/kotlin/io/javalin/jte/precompiled/JtetestGenerated.java
@@ -1,6 +1,6 @@
 package io.javalin.jte.precompiled;
 
-import io.javalin.TestTemplates.JteTestPage;
+import io.javalin.jte.JteTestPage;
 
 public final class JtetestGenerated {
     public static final String JTE_NAME = "test.jte";

--- a/src/test/kotlin/io/javalin/jte/precompiled/kte/JtetestGenerated.kt
+++ b/src/test/kotlin/io/javalin/jte/precompiled/kte/JtetestGenerated.kt
@@ -1,6 +1,6 @@
 package io.javalin.jte.precompiled.kte
 
-import io.javalin.TestTemplates.JteTestPage
+import io.javalin.jte.JteTestPage
 
 class JtetestGenerated {
     companion object {

--- a/src/test/resources/templates/jte/kte/test.kte
+++ b/src/test/resources/templates/jte/kte/test.kte
@@ -1,3 +1,3 @@
-@import io.javalin.TestTemplates.JteTestPage
+@import io.javalin.jte.JteTestPage
 @param page:JteTestPage
 <h1>${page.hello} ${page.world}!</h1>

--- a/src/test/resources/templates/jte/test.jte
+++ b/src/test/resources/templates/jte/test.jte
@@ -1,3 +1,3 @@
-@import io.javalin.TestTemplates.JteTestPage
+@import io.javalin.jte.JteTestPage
 @param JteTestPage page
 <h1>${page.getHello()} ${page.getWorld()}!</h1>


### PR DESCRIPTION
I was able to reproduce #1 locally. Somehow the generated Java template could not access the JteTestPage data class located within TestTemplates.kt.

I migrated JteTestPage to a plain old Java class, which locally did the trick.

Let's see if this fixes it on your CI, too.

If all goes well, I can bump to jte `2.1.1` if you like :-)