### PR TITLE
Bump jte version to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,13 @@
         <dependency>
             <groupId>gg.jte</groupId>
             <artifactId>jte</artifactId>
-            <version>1.12.0</version>
+            <version>2.1.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>gg.jte</groupId>
             <artifactId>jte-kotlin</artifactId>
-            <version>1.12.0</version>
+            <version>2.1.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump to current jte version. jte 2 migration guide: https://github.com/casid/jte/releases/tag/2.0.0

javalin-rendering doesn't make use of template calls, thus unaffected by the upgrade.